### PR TITLE
Suggested change to action.yaml to use github.event.release.tag_name

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -40,6 +40,8 @@ runs:
           IMAGE_TAG=pr-${{ github.event.number }}
         elif [ "${{ github.event_name }}" = "push" ]; then
           IMAGE_TAG="sha-${GITHUB_SHA::7}"
+        elif [ "${{ github.event.release.tag_name }}" = "refs/tags/*" ]; then
+          IMAGE_TAG="${{ github.event.release.tag_name #refs/tags }}"
         fi
         echo "image-tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
     - name: Build, tag, and push image to Amazon ECR


### PR DESCRIPTION
There are currently bugs with tags being created by releases - see [#1](https://github.com/actions/runner/issues/2788) and [#2](https://github.com/orgs/community/discussions/64528) (linked from #1), as `github.ref_name` is no longer populated.
[Comments in #2](https://github.com/orgs/community/discussions/64528#discussioncomment-6784503) suggest that this can be resolved by using `github.event.release.tag_name` instead.

This issue does appear to be affecting the workflows in our Analytical Platform project [moj-analytical-services/airflow-electronicmonitoring-transform](https://github.com/moj-analytical-services/airflow-electronicmonitoring-transform).

My bash scripting syntax is considerably rusty, but I'm submitting this PR that I think should fix the issue? I'd appreciate a review by somebody who is more familiar with GH actions and the MoJ codebase though!